### PR TITLE
Added create_zato_scheduler role to do the initial configuration for the Zato Scheduler

### DIFF
--- a/ansible/roles/create_zato_scheduler/defaults/main.yml
+++ b/ansible/roles/create_zato_scheduler/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+component: zato-scheduler
+ca_certs_path: /opt/zato/ca/ca_cert.pem
+cert_path: /opt/zato/ca/zato-scheduler.cert.pem
+path: /opt/zato/env/scheduler
+priv_key_path: /opt/zato/ca/zato-scheduler.key.pem
+pub_key_path: /opt/zato/ca/zato-scheduler.key.pub.pem

--- a/ansible/roles/create_zato_scheduler/tasks/create.yml
+++ b/ansible/roles/create_zato_scheduler/tasks/create.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Create a directory for Zato scheduler
+  file: path={{ path }}
+    owner=zato group=zato
+    state=directory
+
+- name: Generate zato_scheduler.config file
+  template: src=zato_scheduler.j2 dest=/opt/zato/zato_scheduler.config
+    owner=zato group=zato
+    mode=0600
+
+- name: Create Zato load balancer
+  command: ./current/bin/zato from-config zato_scheduler.config
+    chdir=/opt/zato
+  become_user: zato
+
+- name: Create a symlink to Zato startup script
+  file: src={{ path }}
+    dest=/etc/zato/components-enabled/scheduler
+    state=link
+
+- name: Start Zato scheduler as a service
+  service: name=zato state=started enabled=yes
+
+- pause: seconds=15

--- a/ansible/roles/create_zato_scheduler/tasks/generate_certs.yml
+++ b/ansible/roles/create_zato_scheduler/tasks/generate_certs.yml
@@ -1,0 +1,38 @@
+---
+
+- name: Create a directory to store a component's certificate and keys
+  file: path=/opt/zato/ca state=directory owner=zato group=zato
+
+- name: Copy CA to a Zato host
+  copy: src={{ item }} dest=/opt/zato/ca owner=zato group=zato
+  with_items:
+    - ca_cert.pem
+    - zato_ca.key.pem
+
+- name: Generate private keys for a Zato component
+  command: openssl genrsa -out {{ component }}.key.pem 2048
+    chdir=/opt/zato/ca
+
+- name: Generate public keys for a Zato component
+  command: openssl rsa -in {{ component }}.key.pem -pubout -out {{ component }}.key.pub.pem
+    chdir=/opt/zato/ca
+
+- name: Create certificate signing request
+  command: openssl req -new -key {{ component }}.key.pem -out {{ component }}.req.csr \
+         -subj "/C=EU/ST=Zatoland/L=Zato City/O=Zato/CN={{ component }}"
+    chdir=/opt/zato/ca
+
+- name: Create certificates for a Zato component
+  command: openssl x509 -req -days 365 -in {{ component }}.req.csr -CA ca_cert.pem \
+         -CAkey zato_ca.key.pem -CAcreateserial -out {{ component }}.cert.pem
+    chdir=/opt/zato/ca
+
+- name: Remove left-over certificate signing request
+  file:
+    path=/opt/zato/ca/{{ component }}.req.csr
+    state=absent
+
+- name: Remove left-over rsl file
+  file:
+    path=/opt/zato/ca/ca_cert.srl
+    state=absent

--- a/ansible/roles/create_zato_scheduler/tasks/main.yml
+++ b/ansible/roles/create_zato_scheduler/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+
+- include: generate_certs.yml
+- include: create.yml

--- a/ansible/roles/create_zato_scheduler/templates/zato_scheduler.j2
+++ b/ansible/roles/create_zato_scheduler/templates/zato_scheduler.j2
@@ -1,0 +1,30 @@
+# zato create scheduler config
+ca_certs_path={{ ca_certs_path }}
+cert_path={{ cert_path }}
+cluster_name={{ cluster_name }}
+command=create_scheduler
+kvdb_host={{ broker['host'] }}
+kvdb_port={{ broker['port'] }}
+kvdb_password=
+path={{ path }}
+priv_key_path={{ priv_key_path }}
+pub_key_path={{ pub_key_path }}
+odb_db_name={{ odb['name'] }}
+odb_user={{ odb['user'] }}
+odb_password={{ odb['pass'] }}
+{% if odb_type == "postgresql" %}
+odb_host={{ odb['host'] }}
+odb_port={{ odb['postgresql']['port'] }}
+odb_type=postgresql
+postgresql_schema={{ odb['postgresql']['schema'] }}
+{% elif odb_type == "mysql" %}
+odb_host={{ odb['host'] }}
+odb_port={{ odb['mysql']['port'] }}
+odb_type=mysql
+{% elif odb_type == "oracle" %}
+odb_host={{ odb['host'] }}
+odb_port={{ odb['oracle']['port'] }}
+odb_type=oracle
+{% endif %}
+cluster_id=1
+store_config=False


### PR DESCRIPTION
Hi Zato Friends,

It looks like the Zato Scheduler is currently missing in the Ansible folder. I've created a role for this deamon in line with the rest.

Please note that I hardcoded the cluster_id parameter. You might want to make this configurable somehow.

--Teun