### PR TITLE
Installing latest zato from repository instead of using local deb package

### DIFF
--- a/docker/cloud/Dockerfile
+++ b/docker/cloud/Dockerfile
@@ -22,9 +22,7 @@ RUN curl -s https://zato.io/repo/zato-0CBD7F72.pgp.asc | apt-key add -
 
 # Add Zato repo and install the package
 # update sources and install Zato
-RUN apt-add-repository https://zato.io/repo/stable/3.0/ubuntu && apt-get update && apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev postgresql-client
-ADD zato-3.1.0-python_amd64-bionic.deb /zato-3.1.0-python_amd64-bionic.deb
-RUN dpkg -i /zato-3.1.0-python_amd64-bionic.deb ; apt-get install -f -y && rm -f /zato-3.1.0-python3_amd64-bionic.deb
+RUN apt-add-repository https://zato.io/repo/stable/3.0/ubuntu && apt-get update && apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev postgresql-client zato
 
 # Download Dockerize
 ENV DOCKERIZE_VERSION v0.11.0


### PR DESCRIPTION
Current Dockerfile assumes we have zato deb package available.

But the only way to get deb package is to either build manually or download from repo, which is not that obvious.

