### PR TITLE
Missing image in registry

### DIFF
--- a/docker/kubernetes/zato-k8.yaml.template
+++ b/docker/kubernetes/zato-k8.yaml.template
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
       - name: scheduler
-        image: registry.gitlab.com/zatosource/docker-registry/cloud:3.1
+        image: registry.gitlab.com/zatosource/docker-registry/cloud:3.1-py3
         imagePullPolicy: "Always"
         env:
           - name: ZATO_POSITION
@@ -166,7 +166,7 @@ spec:
     spec:
       containers:
       - name: bootstrap
-        image: registry.gitlab.com/zatosource/docker-registry/cloud:3.1
+        image: registry.gitlab.com/zatosource/docker-registry/cloud:3.1-py3
         imagePullPolicy: "Always"
         env:
           - name: ZATO_POSITION
@@ -225,7 +225,7 @@ spec:
     spec:
       containers:
       - name: webadmin
-        image: registry.gitlab.com/zatosource/docker-registry/cloud:3.1
+        image: registry.gitlab.com/zatosource/docker-registry/cloud:3.1-py3
         imagePullPolicy: "Always"
         env:
           - name: ZATO_POSITION
@@ -286,7 +286,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: registry.gitlab.com/zatosource/docker-registry/cloud:3.1
+        image: registry.gitlab.com/zatosource/docker-registry/cloud:3.1-py3
         imagePullPolicy: "Always"
         env:
           - name: ZATO_POSITION


### PR DESCRIPTION
Hello, sorry, but it seems, that image registry.gitlab.com/zatosource/docker-registry/cloud:3.1 doesn-t exists in registry.